### PR TITLE
Cleanup org-tweetyproject-arg-aspic module

### DIFF
--- a/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/examples/AspicGeneratorExample.java
+++ b/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/examples/AspicGeneratorExample.java
@@ -32,30 +32,28 @@ import org.tweetyproject.logics.pl.syntax.PlFormula;
 
 /**
  * Exemplary code illustrating the use of the ASPIC theory generator.
- * Furthermore this code show a small performance comparison between
- * the naive ASPIC reasoner, the module based reasoner, and the random reasoner.
- * 
- * @author Matthias Thimm
+ * Furthermore, this code show a small performance comparison between
+ * the naive ASPIC reasoner, the module based reasoner, directional reasoner,
+ * and the random reasoner.
  *
+ * @author Matthias Thimm
  */
 public class AspicGeneratorExample {
 	/**
-	 * 
 	 * @param args command line args
 	 */
-	@SuppressWarnings("deprecation")
-	public static void main(String[] args) {		 
+	public static void main(String[] args) {
 		int repetitions = 50;
 		int numberAtoms = 35;
 		int numberFormulas = 100;
 		int maxLiteralsInPremises = 2;
 		double percentageStrictRules = 0.2;
-		
-		SimpleAspicReasoner<PlFormula> naiveReasoner = new SimpleAspicReasoner<PlFormula>(AbstractExtensionReasoner.getSimpleReasonerForSemantics(Semantics.GR));
-		ModuleBasedAspicReasoner<PlFormula> moduleBasedReasoner = new ModuleBasedAspicReasoner<PlFormula>(AbstractExtensionReasoner.getSimpleReasonerForSemantics(Semantics.GR));
-		DirectionalAspicReasoner<PlFormula> dirReasoner = new DirectionalAspicReasoner<PlFormula>(AbstractExtensionReasoner.getSimpleReasonerForSemantics(Semantics.GR));
-		RandomAspicReasoner<PlFormula> randomReasoner = new RandomAspicReasoner<PlFormula>(AbstractExtensionReasoner.getSimpleReasonerForSemantics(Semantics.GR),600,100);
-		
+
+		SimpleAspicReasoner<PlFormula> naiveReasoner = new SimpleAspicReasoner<>(AbstractExtensionReasoner.getSimpleReasonerForSemantics(Semantics.GR));
+		ModuleBasedAspicReasoner<PlFormula> moduleBasedReasoner = new ModuleBasedAspicReasoner<>(AbstractExtensionReasoner.getSimpleReasonerForSemantics(Semantics.GR));
+		DirectionalAspicReasoner<PlFormula> dirReasoner = new DirectionalAspicReasoner<>(AbstractExtensionReasoner.getSimpleReasonerForSemantics(Semantics.GR));
+		RandomAspicReasoner<PlFormula> randomReasoner = new RandomAspicReasoner<>(AbstractExtensionReasoner.getSimpleReasonerForSemantics(Semantics.GR), 600, 100);
+
 		long totalNaive = 0;
 		long totalModulebased = 0;
 		long totalDirectional = 0;
@@ -63,36 +61,36 @@ public class AspicGeneratorExample {
 		long correctRandom = 0;
 		long correctDirectional = 0;
 		RandomAspicArgumentationTheoryGenerator gen = new RandomAspicArgumentationTheoryGenerator(numberAtoms, numberFormulas, maxLiteralsInPremises, percentageStrictRules);
-		for(int i = 0; i < repetitions; i++) {
+		for (int i = 0; i < repetitions; i++) {
 			AspicArgumentationTheory<PlFormula> theory = gen.next();
 			System.out.println(i + "\t" + theory);
 			PlFormula query = new Proposition("A1");
 			// Naive
 			long millis = System.currentTimeMillis();
-			boolean answer = naiveReasoner.query(theory,query,InferenceMode.CREDULOUS);
-			totalNaive += System.currentTimeMillis()-millis;
+			boolean answer = naiveReasoner.query(theory, query, InferenceMode.CREDULOUS);
+			totalNaive += System.currentTimeMillis() - millis;
 			// Module
 			millis = System.currentTimeMillis();
-			moduleBasedReasoner.query(theory,query,InferenceMode.CREDULOUS);
-			totalModulebased += System.currentTimeMillis()-millis;
+			moduleBasedReasoner.query(theory, query, InferenceMode.CREDULOUS);
+			totalModulebased += System.currentTimeMillis() - millis;
 			// Directional
 			millis = System.currentTimeMillis();
-			if(dirReasoner.query(theory,query,InferenceMode.CREDULOUS) == answer)
+			if (dirReasoner.query(theory, query, InferenceMode.CREDULOUS) == answer)
 				correctDirectional++;
-			totalDirectional += System.currentTimeMillis()-millis;
+			totalDirectional += System.currentTimeMillis() - millis;
 			// Random
 			millis = System.currentTimeMillis();
-			if(randomReasoner.query(theory,query,InferenceMode.CREDULOUS) == answer)
+			if (randomReasoner.query(theory, query, InferenceMode.CREDULOUS) == answer)
 				correctRandom++;
-			totalRandom += System.currentTimeMillis()-millis;
-		}	
+			totalRandom += System.currentTimeMillis() - millis;
+		}
 		System.out.println();
 		System.out.println("Runtime naive reasoner: " + totalNaive + "ms");
-		System.out.println("Runtime module-based reasoner: " +  totalModulebased+ "ms");
-		System.out.println("Runtime directional reasoner: " +  totalDirectional+ "ms");
-		System.out.println("Runtime random reasoner: " +  totalRandom + "ms");
-		System.out.println("Accuracy directional reasoner: " +(new Double(correctDirectional)/(repetitions)));
-		System.out.println("Accuracy random reasoner: " +(new Double(correctRandom)/(repetitions)));
-	}	
-	
+		System.out.println("Runtime module-based reasoner: " + totalModulebased + "ms");
+		System.out.println("Runtime directional reasoner: " + totalDirectional + "ms");
+		System.out.println("Runtime random reasoner: " + totalRandom + "ms");
+		System.out.println("Accuracy directional reasoner: " + (1.0 * correctDirectional) / (repetitions));
+		System.out.println("Accuracy random reasoner: " + (1.0 * correctRandom) / (repetitions));
+	}
+
 }

--- a/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/reasoner/DirectionalAspicReasoner.java
+++ b/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/reasoner/DirectionalAspicReasoner.java
@@ -116,10 +116,10 @@ public class DirectionalAspicReasoner<T extends Invertable> extends AbstractAspi
 
 	private Set<AspicArgument<T>> constructArgsWithConclusion(AspicArgumentationTheory<T> aat, T conc, Set<T> conclusions) {
 	
-		conclusions = new HashSet<T>(conclusions);
+		conclusions = new HashSet<>(conclusions);
 		conclusions.add(conc);
 
-		Set<AspicArgument<T>> result = new LinkedHashSet<AspicArgument<T>>();
+		Set<AspicArgument<T>> result = new LinkedHashSet<>();
 		outer: for (InferenceRule<T> rule: aat.getRulesWithConclusion(conc)) {
 			// Skip rules where conclusion is repeated as premise
 			for (T premise: rule.getPremise()) {
@@ -128,9 +128,9 @@ public class DirectionalAspicReasoner<T extends Invertable> extends AbstractAspi
 				}
 			}
 			// Set up list of partial args (i.e. may not contain necessary sub args)
-			Set<AspicArgument<T>> newPartialArgs = new LinkedHashSet<AspicArgument<T>>();
-			Set<AspicArgument<T>> partialArgs = new LinkedHashSet<AspicArgument<T>>();
-			partialArgs.add(new AspicArgument<T>(rule));
+			Set<AspicArgument<T>> newPartialArgs = new LinkedHashSet<>();
+			Set<AspicArgument<T>> partialArgs = new LinkedHashSet<>();
+			partialArgs.add(new AspicArgument<>(rule));
 
 			// For each premise ...
 			for (T premise: rule.getPremise()) {
@@ -138,7 +138,6 @@ public class DirectionalAspicReasoner<T extends Invertable> extends AbstractAspi
 				Set<AspicArgument<T>> subArgs = constructArgsWithConclusion(aat, premise, conclusions);
 				
 				// Update and replace all partial args
-				newPartialArgs.clear();
 				for (AspicArgument<T> partialArg: partialArgs) {
 					for (AspicArgument<T> subArg: subArgs) {
 						AspicArgument<T> partialArgCopy = partialArg.shallowCopy();
@@ -164,16 +163,14 @@ public class DirectionalAspicReasoner<T extends Invertable> extends AbstractAspi
 	 * @return	arguments with given conclusion plus recursively all attackers 
 	 */
 	private Collection<AspicArgument<T>> getArgsRec(AspicArgumentationTheory<T> aat, T conc) {
-			
 		
 		Random r = new Random();
 		
-		Set<AspicArgument<T>> newArgs = new LinkedHashSet<AspicArgument<T>>();
-		Set<AspicArgument<T>> args = new LinkedHashSet<AspicArgument<T>>();
-		Set<AspicArgument<T>> argsDone = new HashSet<AspicArgument<T>>();
-		Set<T> conclusionsDone = new HashSet<T>();
+		Set<AspicArgument<T>> newArgs = new LinkedHashSet<>();
+		Set<AspicArgument<T>> argsDone = new HashSet<>();
+		Set<T> conclusionsDone = new HashSet<>();
 
-		args.addAll(constructArgsWithConclusion(aat, conc, new HashSet<T>()));
+		Set<AspicArgument<T>> args = new LinkedHashSet<>(constructArgsWithConclusion(aat, conc, new HashSet<>()));
 		conclusionsDone.add(conc);
 		
 		boolean repeat = true;
@@ -187,7 +184,7 @@ public class DirectionalAspicReasoner<T extends Invertable> extends AbstractAspi
 					for (T conclusion: getAttackingConclusions(argument, aat.getRuleFormulaGenerator())) {
 						if (!conclusionsDone.contains(conclusion)) {
 							conclusionsDone.add(conclusion);
-							newArgs.addAll(constructArgsWithConclusion(aat, conclusion, new HashSet<T>()));
+							newArgs.addAll(constructArgsWithConclusion(aat, conclusion, new HashSet<>()));
 						}
 					}
 				}
@@ -213,7 +210,7 @@ public class DirectionalAspicReasoner<T extends Invertable> extends AbstractAspi
 	 */
 	@SuppressWarnings("unchecked")
 	public Collection<T> getAttackingConclusions(AspicArgument<T> arg, RuleFormulaGenerator<T> rfgen) {
-		Collection<T> cs = new ArrayList<T>();
+		Collection<T> cs = new ArrayList<>();
 		Objects.requireNonNull(rfgen);
 		// Add undercutters
 		for (InferenceRule<T> dr: arg.getDefeasibleRules()) {

--- a/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/ruleformulagenerator/FolFormulaGenerator.java
+++ b/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/ruleformulagenerator/FolFormulaGenerator.java
@@ -18,8 +18,6 @@
  */
 package org.tweetyproject.arg.aspic.ruleformulagenerator;
 
-
-
 import java.util.Collections;
 
 import org.tweetyproject.arg.aspic.syntax.DefeasibleInferenceRule;
@@ -30,29 +28,25 @@ import org.tweetyproject.logics.fol.syntax.FolAtom;
 import org.tweetyproject.logics.fol.syntax.FolFormula;
 
 /**
- * @author Nils Geilen
- * 
  * Implements <code>RuleFormulaGenerator</code> for first order logic.
  * If a rule has been given a name, it is employed as an identifier.
+ *
+ * @author Nils Geilen
  */
 public class FolFormulaGenerator extends RuleFormulaGenerator<FolFormula> {
-	
-	
+
 	/**
-	 * Constants needed for atom creation 
+	 * Constants needed for atom creation
 	 */
 	final static Sort sort = new Sort("Rule");
-	final static Predicate RULE_PREDICATE = new Predicate("__rule", Collections.singletonList(sort) );
-	
+	final static Predicate RULE_PREDICATE = new Predicate("__rule", Collections.singletonList(sort));
 
 	/* (non-Javadoc)
 	 * @see ruleformulagenerator.RuleFormulaGenerator#getRuleFormula(org.tweetyproject.arg.aspic.syntax.InferenceRule)
 	 */
 	@Override
-	public FolFormula getRuleFormula(DefeasibleInferenceRule<FolFormula> r)  {		
-		Constant rcons = new Constant( r.getIdentifier() , sort);
+	public FolFormula getRuleFormula(DefeasibleInferenceRule<FolFormula> r) {
+		Constant rcons = new Constant(r.getIdentifier(), sort);
 		return new FolAtom(RULE_PREDICATE, rcons);
 	}
-
-
 }

--- a/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/ruleformulagenerator/PlFormulaGenerator.java
+++ b/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/ruleformulagenerator/PlFormulaGenerator.java
@@ -23,10 +23,10 @@ import org.tweetyproject.logics.pl.syntax.Proposition;
 import org.tweetyproject.logics.pl.syntax.PlFormula;
 
 /**
- * @author Nils Geilen
- * 
  * Implements <code>RuleFormulaGenerator</code> for propositional logic.
  * If a rule has been given a name, it is employed as an identifier.
+ *
+ * @author Nils Geilen
  */
 public class PlFormulaGenerator extends RuleFormulaGenerator<PlFormula> {
 

--- a/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/ruleformulagenerator/RuleFormulaGenerator.java
+++ b/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/ruleformulagenerator/RuleFormulaGenerator.java
@@ -24,24 +24,21 @@ import org.tweetyproject.arg.aspic.syntax.InferenceRule;
 import org.tweetyproject.logics.commons.syntax.interfaces.Invertable;
 
 /**
+ * This class transforms a defeasible ASPIC inference rule into a
+ * corresponding formula, i.e. a word in the language of the conclusion
+ * and the premises of that rule, which can be used in the head of an
+ * inference rule.
+ *
+ * @param <T> is the type of the returned formula
  * @author Nils Geilen
- * 
- *         This class transforms a defeasible ASPIC inference rule into a
- *         corresponding formula, i.e. a word in the language of the conclusion
- *         and the premises of that rule, which can be used in the head of an
- *         inference rule.
- * 
- * @param <T>
- *            is the type of the returned formula
  */
 public abstract class RuleFormulaGenerator<T extends Invertable> {
 
 	/**
 	 * Transforms a defeasible ASPIC inference rule into a corresponding formula
 	 * of type <code>T</code>
-	 * 
-	 * @param r
-	 *            is the inferende rule to be transformed
+	 *
+	 * @param r is the inferende rule to be transformed
 	 * @return a formula of type <code>T</code>
 	 */
 	public abstract T getRuleFormula(DefeasibleInferenceRule<T> r);
@@ -49,11 +46,9 @@ public abstract class RuleFormulaGenerator<T extends Invertable> {
 	/**
 	 * Transforms a formula of type <code>T</code> into a corresponding
 	 * defeasible ASPIC inference rule form the knowledge base <code>kb</code>
-	 * 
-	 * @param formula
-	 *            is a formula of type <code>T</code>
-	 * @param kb
-	 *            is the knowledge base the is searched for the rule
+	 *
+	 * @param formula is a formula of type <code>T</code>
+	 * @param kb      is the knowledge base the is searched for the rule
 	 * @return the corresponding inference rule
 	 */
 	public DefeasibleInferenceRule<T> getInferenceRule(T formula, AspicArgumentationTheory<T> kb) {

--- a/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/semantics/AspicAttack.java
+++ b/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/semantics/AspicAttack.java
@@ -29,11 +29,10 @@ import org.tweetyproject.arg.dung.syntax.Attack;
 import org.tweetyproject.logics.commons.syntax.interfaces.Invertable;
 
 /**
- * @author Nils Geilen
- * 
  * Checks whether an argument defeats another argument
- * 
- * @param <T>	is the type of the language that the ASPIC theory's rules range over 
+ *
+ * @param <T> is the type of the language that the ASPIC theory's rules range over
+ * @author Nils Geilen
  */
 public class AspicAttack<T extends Invertable> extends Attack {
 	
@@ -56,11 +55,11 @@ public class AspicAttack<T extends Invertable> extends Attack {
 	 */
 	public static <T extends Invertable> Collection<AspicAttack<T>> determineAttackRelations(Collection<AspicArgument<T>> args, Comparator<AspicArgument<T>> order, RuleFormulaGenerator<T> rfgen) {
 		Collection<AspicAttack<T>> successfull = new ArrayList<>();
-		for (AspicArgument<T> active : args) 
+		for (AspicArgument<T> active : args)
 			for (AspicArgument<T> passive : args)
 				if (active != passive) {
 					if(AspicAttack.isAttack(active,passive,rfgen,order)) {
-						successfull.add(new AspicAttack<T>(active, passive));
+						successfull.add(new AspicAttack<>(active, passive));
 					}
 				}
 		return successfull;
@@ -79,12 +78,7 @@ public class AspicAttack<T extends Invertable> extends Attack {
 		Collection<AspicArgument<T>> defargs = passive.getDefeasibleSubs();		
 		// default order
 		if(order == null)
-			order = new Comparator<AspicArgument<T>>() {
-				@Override
-				public int compare(AspicArgument<T> o1, AspicArgument<T> o2) {
-					return 0;
-				}
-			};		
+			order = (o1, o2) -> 0;
 		/*
 		 * Undercutting
 		 */

--- a/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/semantics/SimpleAspicOrder.java
+++ b/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/semantics/SimpleAspicOrder.java
@@ -27,11 +27,10 @@ import org.tweetyproject.arg.aspic.syntax.AspicArgument;
 import org.tweetyproject.logics.commons.syntax.interfaces.Invertable;
 
 /**
- * @author Nils Geilen
- * 
  * A simple comparator for Aspic Arguments, that compares their top rules according to a given list of rules
- * 
- * @param <T>	is the type of the language that the ASPIC theory's rules range over 
+ *
+ * @param <T> is the type of the language that the ASPIC theory's rules range over
+ * @author Nils Geilen
  */
 public class SimpleAspicOrder<T extends Invertable> implements Comparator<AspicArgument<T>> {
 	

--- a/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/syntax/AspicArgument.java
+++ b/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/syntax/AspicArgument.java
@@ -18,35 +18,26 @@
  */
 package org.tweetyproject.arg.aspic.syntax;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-
 import org.tweetyproject.arg.aspic.ruleformulagenerator.RuleFormulaGenerator;
 import org.tweetyproject.arg.dung.syntax.Argument;
 import org.tweetyproject.logics.commons.syntax.interfaces.Invertable;
 
-/**
- * 
- * @author Nils Geilen
- *
- * An argument according to the ASPIC+ specification
- * 
- * @param <T>	is the type of the language that the ASPIC theory's rules range over 
- */
+import java.util.*;
 
+/**
+ * An argument according to the ASPIC+ specification
+ * @param <T> is the type of the language that the ASPIC theory's rules range over
+ *
+ * @author Nils Geilen
+ */
 public class AspicArgument<T extends Invertable> extends Argument {
 	
 	/** The conclusion of the argument's top rule **/
-	private T conc = null;;
+	private T conc;
 	/** The argument's direct children, whose conclusions fit its prerequisites **/
 	private List<AspicArgument<T>> directsubs = new ArrayList<>();
 	/** The srgument's top rule **/
-	private InferenceRule<T> toprule = null;
+	private InferenceRule<T> toprule;
 	
 	
 	/**
@@ -58,7 +49,7 @@ public class AspicArgument<T extends Invertable> extends Argument {
 		super(null);
 		this.toprule = toprule;
 		conc = toprule.getConclusion();	
-		this.directsubs = new LinkedList<AspicArgument<T>>(directsubs);
+		this.directsubs = new LinkedList<>(directsubs);
 		
 		generateName();
 	}
@@ -80,12 +71,7 @@ public class AspicArgument<T extends Invertable> extends Argument {
 	 * and is used to determine equality 
 	 */
 	private void generateName() {
-		Collections.sort(directsubs, new Comparator<AspicArgument<T>>() {
-			@Override
-			public int compare(AspicArgument<T> o1, AspicArgument<T> o2) {
-				return o1.hashCode() - o2.hashCode();
-			}
-		});
+		directsubs.sort(Comparator.comparingInt(AspicArgument::hashCode));
 		setName(toprule + (directsubs.isEmpty()  ? "": " "+directsubs ));
 	}
 		
@@ -294,11 +280,8 @@ public class AspicArgument<T extends Invertable> extends Argument {
 		} else if (!directsubs.equals(other.directsubs))
 			return false;
 		if (toprule == null) {
-			if (other.toprule != null)
-				return false;
-		} else if (!toprule.equals(other.toprule))
-			return false;
-		return true;
+			return other.toprule == null;
+		} else return toprule.equals(other.toprule);
 	}
 
 	/**
@@ -350,12 +333,7 @@ public class AspicArgument<T extends Invertable> extends Argument {
 		Collection<AspicArgument<T>> defargs = passive.getDefeasibleSubs();		
 		// default order
 		if(order == null)
-			order = new Comparator<AspicArgument<T>>() {
-				@Override
-				public int compare(AspicArgument<T> o1, AspicArgument<T> o2) {
-					return 0;
-				}
-			};		
+			order = (o1, o2) -> 0;
 		/*
 		 * Undercutting
 		 */
@@ -389,8 +367,8 @@ public class AspicArgument<T extends Invertable> extends Argument {
 	 * @return a shallow copy
 	 */
 	public AspicArgument<T> shallowCopy() {
-		AspicArgument<T> copy = new AspicArgument<T>(toprule);
-		directsubs.forEach(sub -> copy.addDirectSub(sub));
+		AspicArgument<T> copy = new AspicArgument<>(toprule);
+		directsubs.forEach(copy::addDirectSub);
 		return copy;
 	}
 

--- a/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/syntax/AspicArgumentationTheory.java
+++ b/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/syntax/AspicArgumentationTheory.java
@@ -37,20 +37,18 @@ import org.tweetyproject.logics.commons.syntax.interfaces.Invertable;
 import org.tweetyproject.logics.fol.syntax.FolSignature;
 
 /**
- * @author Nils Geilen
- * @author Matthias Thimm
- *
- *         According to Modgil and Prakken
- *         (http://www.cs.uu.nl/groups/IS/archive/henry/ASPICtutorial.pdf) this
- *         represents an argumentation theory (AS, KB) with - AS argumentation
- *         system (e.g. inference rules) - KB knowledge base and/or a
- *         corresponding structured argumentation framework (A,C,&lt;=) with - A
- *         set of arguments - C set of attacks - &lt;= order on the arguments
- *         and/or a corresponding abstract argumentation framework (A, D) with -
- *         A set of arguments - D defeat relationship
+ * According to  <a href="http://www.cs.uu.nl/groups/IS/archive/henry/ASPICtutorial.pdf">Modgil and Prakken</a>,
+ * this represents an argumentation theory (AS, KB) with - AS argumentation
+ * system (e.g. inference rules) - KB knowledge base and/or a
+ * corresponding structured argumentation framework (A,C,&lt;=) with - A
+ * set of arguments - C set of attacks - &lt;= order on the arguments
+ * and/or a corresponding abstract argumentation framework (A, D) with -
+ * A set of arguments - D defeat relationship
  *
  * @param <T> is the type of the language that the ASPIC theory's rules range
  *            over
+ * @author Nils Geilen
+ * @author Matthias Thimm
  */
 public class AspicArgumentationTheory<T extends Invertable> extends RuleSet<InferenceRule<T>> implements BeliefBase {
 
@@ -68,7 +66,7 @@ public class AspicArgumentationTheory<T extends Invertable> extends RuleSet<Infe
 
 	/**
 	 * Constructs a new ASPIC argumentation theory
-	 * 
+	 *
 	 * @param rfgen function to map defeasible rules to labels
 	 */
 	public AspicArgumentationTheory(RuleFormulaGenerator<T> rfgen) {
@@ -79,7 +77,7 @@ public class AspicArgumentationTheory<T extends Invertable> extends RuleSet<Infe
 	/**
 	 * Set a new generator to transform rules into words of the language they range
 	 * over
-	 * 
+	 *
 	 * @param rfg is the new formula generator
 	 */
 	public void setRuleFormulaGenerator(RuleFormulaGenerator<T> rfg) {
@@ -89,7 +87,7 @@ public class AspicArgumentationTheory<T extends Invertable> extends RuleSet<Infe
 	/**
 	 * Returns the generator to transform rules into words of the language they
 	 * range over
-	 * 
+	 *
 	 * @return the formula generator
 	 */
 	public RuleFormulaGenerator<T> getRuleFormulaGenerator() {
@@ -97,8 +95,8 @@ public class AspicArgumentationTheory<T extends Invertable> extends RuleSet<Infe
 	}
 
 	/**
-	 * Adds an additional inference rule
-	 * 
+	 * Adds an inference rule
+	 *
 	 * @param rule the rule to be added
 	 */
 	public void addRule(InferenceRule<T> rule) {
@@ -106,8 +104,8 @@ public class AspicArgumentationTheory<T extends Invertable> extends RuleSet<Infe
 	}
 
 	/**
-	 * Adds an additional axiom, i.e. a strict rule without premise
-	 * 
+	 * Adds an axiom, i.e. a strict rule without premise
+	 *
 	 * @param axiom the axiom's conclusion
 	 */
 	public void addAxiom(T axiom) {
@@ -117,8 +115,8 @@ public class AspicArgumentationTheory<T extends Invertable> extends RuleSet<Infe
 	}
 
 	/**
-	 * Adds an additional ordinary, i.e. a defeasible inference rule without premise
-	 * 
+	 * Adds an ordinary premise, i.e. a defeasible inference rule without premise
+	 *
 	 * @param prem the premise's conclusion
 	 */
 	public void addOrdinaryPremise(T prem) {
@@ -130,9 +128,9 @@ public class AspicArgumentationTheory<T extends Invertable> extends RuleSet<Infe
 	/**
 	 * This method transfers this Aspic+ theory into a Dung style argumentation
 	 * system
-	 * 
+	 *
 	 * @return a dung theory constructed out of this system's arguments and their
-	 *         defeat relation according to order
+	 * defeat relation according to order
 	 */
 	public DungTheory asDungTheory() {
 		return this.asDungTheory(false);
@@ -141,7 +139,7 @@ public class AspicArgumentationTheory<T extends Invertable> extends RuleSet<Infe
 	/**
 	 * This method transfers this Aspic+ theory into a Dung style argumentation
 	 * system
-	 * 
+	 *
 	 * @param simplifyArgumentStructure whether the argument class should be
 	 *                                  simplified; if "false" then
 	 *                                  <code>AspicArgument</code> is used as the
@@ -150,7 +148,7 @@ public class AspicArgumentationTheory<T extends Invertable> extends RuleSet<Infe
 	 *                                  argument (the structure of the arguments is
 	 *                                  therefore lost).
 	 * @return a dung theory constructed out of this system's arguments and their
-	 *         defeat relation according to order
+	 * defeat relation according to order
 	 */
 	public DungTheory asDungTheory(boolean simplifyArgumentStructure) {
 		Collection<AspicArgument<T>> args = getArguments();
@@ -172,38 +170,38 @@ public class AspicArgumentationTheory<T extends Invertable> extends RuleSet<Infe
 		}
 		return dung_theory2;
 	}
+
 	/**
-	 * 
-	 * @return a set of ground fol rules 
+	 * @return a set of ground fol rules
 	 */
 	public Set<InferenceRule<T>> groundFolRules() {
 		Signature sig = this.getMinimalSignature();
-		if (!(sig instanceof FolSignature)) 
+		if (!(sig instanceof FolSignature))
 			return this;
-		
+
 		FolSignature fsig = (FolSignature) sig;
-		Set<InferenceRule<T>> ground_rules = new HashSet<InferenceRule<T>>();
+		Set<InferenceRule<T>> ground_rules = new HashSet<>();
 		for (InferenceRule<T> r : this) {
-			ground_rules.addAll((Set<InferenceRule<T>>) r.allGroundInstances(fsig.getConstants()));
+			ground_rules.addAll(r.allGroundInstances(fsig.getConstants()));
 		}
 		return ground_rules;
 	}
 
 	/**
-	 * Expands this systems's inference rules into a tree arguments
-	 * 
-	 * @return the arguments constructed from this systems's inference rules
+	 * Expands this system's inference rules into a tree arguments
+	 *
+	 * @return the arguments constructed from this system's inference rules
 	 */
 	public Collection<AspicArgument<T>> getArguments() {
 		Collection<AspicArgument<T>> args = new HashSet<>();
 		Collection<Collection<AspicArgument<T>>> subs = new HashSet<>();
 		Collection<Collection<AspicArgument<T>>> new_subs = new HashSet<>();
 		Collection<AspicArgument<T>> argsForPrem = new HashSet<>();
-		
+
 		Set<InferenceRule<T>> rules = this.groundFolRules();
 		for (InferenceRule<T> rule : rules) {
-			if (rule.isFact()) 
-				args.add(new AspicArgument<T>(rule));
+			if (rule.isFact())
+				args.add(new AspicArgument<>(rule));
 		}
 		boolean changed;
 		do {
@@ -223,7 +221,7 @@ public class AspicArgumentationTheory<T extends Invertable> extends RuleSet<Infe
 					} else {
 						if (subs.isEmpty()) {
 							for (AspicArgument<T> subarg : argsForPrem) {
-								Collection<AspicArgument<T>> subargset = new HashSet<AspicArgument<T>>();
+								Collection<AspicArgument<T>> subargset = new HashSet<>();
 								subargset.add(subarg);
 								subs.add(subargset);
 							}
@@ -244,7 +242,7 @@ public class AspicArgumentationTheory<T extends Invertable> extends RuleSet<Infe
 				if (continueWithNextRule)
 					continue;
 				for (Collection<AspicArgument<T>> subargset : subs)
-					changed = args.add(new AspicArgument<T>(rule, subargset)) || changed;
+					changed = args.add(new AspicArgument<>(rule, subargset)) || changed;
 			}
 		} while (changed);
 		return args;
@@ -252,7 +250,7 @@ public class AspicArgumentationTheory<T extends Invertable> extends RuleSet<Infe
 
 	/**
 	 * Sets a new order over the arguments
-	 * 
+	 *
 	 * @param order the new order
 	 */
 	public void setOrder(Comparator<AspicArgument<T>> order) {
@@ -268,7 +266,7 @@ public class AspicArgumentationTheory<T extends Invertable> extends RuleSet<Infe
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see java.lang.Object#toString()
 	 */
 	@Override
@@ -278,7 +276,7 @@ public class AspicArgumentationTheory<T extends Invertable> extends RuleSet<Infe
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see org.tweetyproject.commons.BeliefBase#getSignature()
 	 */
 	@Override

--- a/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/syntax/DefeasibleInferenceRule.java
+++ b/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/syntax/DefeasibleInferenceRule.java
@@ -27,12 +27,11 @@ import org.tweetyproject.logics.commons.syntax.interfaces.Term;
 import org.tweetyproject.logics.fol.syntax.FolSignature;
 
 /**
- * @author Nils Geilen
- * 
- *         Defeasible implementation of <code>InferenceRule&lt;T&gt;</code>
+ * Defeasible implementation of <code>InferenceRule&lt;T&gt;</code>
  *
  * @param <T> is the type of the language that the ASPIC theory's rules range
  *            over
+ * @author Nils Geilen
  */
 public class DefeasibleInferenceRule<T extends Invertable> extends InferenceRule<T> {
 
@@ -64,7 +63,7 @@ public class DefeasibleInferenceRule<T extends Invertable> extends InferenceRule
 
 	@Override
 	public DefeasibleInferenceRule<T> clone() {
-		DefeasibleInferenceRule<T> rule = new DefeasibleInferenceRule<T>();
+		DefeasibleInferenceRule<T> rule = new DefeasibleInferenceRule<>();
 		rule.addPremises(this.getPremise());
 		rule.setConclusion(this.getConclusion());
 		return rule;
@@ -76,7 +75,7 @@ public class DefeasibleInferenceRule<T extends Invertable> extends InferenceRule
 		DefeasibleInferenceRule<T> n = this.clone();
 		Signature sig = this.getSignature();
 		if (sig instanceof FolSignature) {
-			n = new DefeasibleInferenceRule<T>();
+			n = new DefeasibleInferenceRule<>();
 			RelationalFormula c2 = ((RelationalFormula) this.getConclusion()).substitute(v, t);
 			for (T x : this.getPremise()) {
 				RelationalFormula p2 = ((RelationalFormula) x).substitute(v, t);

--- a/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/syntax/InferenceRule.java
+++ b/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/syntax/InferenceRule.java
@@ -42,12 +42,11 @@ import org.tweetyproject.logics.commons.syntax.interfaces.Term;
 import org.tweetyproject.logics.fol.syntax.FolSignature;
 
 /**
- * @author Nils Geilen
- * 
  * This stands for an inference rule or for a premise if premises has length 0.
  * If this is a premise and defeasible it is an ordinary premise else it is an axiom.
- * 
- * @param <T>	is the type of the language that the ASPIC theory's rules range over 
+ *
+ * @param <T> is the type of the language that the ASPIC theory's rules range over
+ * @author Nils Geilen
  */
 public abstract class InferenceRule<T extends Invertable> implements Rule<T, T>, ComplexLogicalFormula {
 	
@@ -75,11 +74,8 @@ public abstract class InferenceRule<T extends Invertable> implements Rule<T, T>,
 		} else if (!conclusion.equals(other.conclusion))
 			return false;
 		if (premises == null) {
-			if (other.premises != null)
-				return false;
-		} else if (!premises.equals(other.premises))
-			return false;
-		return true;
+			return other.premises == null;
+		} else return premises.equals(other.premises);
 	}
 	/**
 	 * The rule's conclusion
@@ -256,7 +252,7 @@ public abstract class InferenceRule<T extends Invertable> implements Rule<T, T>,
 	 */
 	public Set<InferenceRule<T>> allGroundInstances(Set<Constant> constants) {
 		Set<Map<Variable, Term<?>>> maps = this.allSubstitutions(constants);
-		Set<InferenceRule<T>> result = new HashSet<InferenceRule<T>>();
+		Set<InferenceRule<T>> result = new HashSet<>();
 		for (Map<Variable, Term<?>> map : maps)
 			result.add(this.substitute(map));
 		return result;
@@ -289,16 +285,16 @@ public abstract class InferenceRule<T extends Invertable> implements Rule<T, T>,
 			throws IllegalArgumentException {
 		Set<Variable> variables = this.getUnboundVariables();
 		// partition variables by sorts
-		Map<Sort, Set<Variable>> sorts_variables = new HashMap<Sort, Set<Variable>>();
+		Map<Sort, Set<Variable>> sorts_variables = new HashMap<>();
 		for (Variable v : variables) {
 			if (!sorts_variables.containsKey(v.getSort()))
-				sorts_variables.put(v.getSort(), new HashSet<Variable>());
+				sorts_variables.put(v.getSort(), new HashSet<>());
 			sorts_variables.get(v.getSort()).add(v);
 		}
 		// partition terms by sorts
 		Map<Sort, Set<Term<?>>> sorts_terms = Sort.sortTerms(terms);
 		// combine the partitions
-		Map<Set<Variable>, Set<Term<?>>> relations = new HashMap<Set<Variable>, Set<Term<?>>>();
+		Map<Set<Variable>, Set<Term<?>>> relations = new HashMap<>();
 		for (Sort s : sorts_variables.keySet()) {
 			if (!sorts_terms.containsKey(s))
 				throw new IllegalArgumentException("There is no term of sort " + s + " to substitute.");
@@ -351,18 +347,18 @@ public abstract class InferenceRule<T extends Invertable> implements Rule<T, T>,
 	
 	@Override
 	public Set<? extends Predicate> getPredicates() {
-		Set<Predicate> predicates = new HashSet<Predicate>();
+		Set<Predicate> predicates = new HashSet<>();
 		Signature sig = this.getSignature();
 		if (sig instanceof FolSignature) {
 			predicates.addAll(((RelationalFormula) this.getPremise()).getPredicates());
-			predicates.addAll(((RelationalFormula) this.getConclusion()).getPredicates());
+			predicates.addAll(this.getConclusion().getPredicates());
 		}
 		return predicates;
 	}
 	
 	@Override
 	public Set<Term<?>> getTerms() {
-		Set<Term<?>> reval = new HashSet<Term<?>>();
+		Set<Term<?>> reval = new HashSet<>();
 		Signature sig = this.getSignature();
 		if (sig instanceof FolSignature) {
 			for (T x : this.getPremise())
@@ -374,7 +370,7 @@ public abstract class InferenceRule<T extends Invertable> implements Rule<T, T>,
 
 	@Override
 	public <C extends Term<?>> Set<C> getTerms(Class<C> cls) {
-		Set<C> reval = new HashSet<C>();
+		Set<C> reval = new HashSet<>();
 		Signature sig = this.getSignature();
 		if (sig instanceof FolSignature) {
 			for (Term<?> arg : this.getTerms()) {

--- a/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/syntax/StrictInferenceRule.java
+++ b/org-tweetyproject-arg-aspic/src/main/java/org/tweetyproject/arg/aspic/syntax/StrictInferenceRule.java
@@ -27,12 +27,11 @@ import org.tweetyproject.logics.commons.syntax.interfaces.Term;
 import org.tweetyproject.logics.fol.syntax.FolSignature;
 
 /**
- * @author Nils Geilen
- * 
- *         Indefeasible implementation of <code>InferenceRule&lt;T&gt;</code>
+ * Indefeasible implementation of <code>InferenceRule&lt;T&gt;</code>
  *
  * @param <T> is the type of the language that the ASPIC theory's rules range
  *            over
+ * @author Nils Geilen
  */
 public class StrictInferenceRule<T extends Invertable> extends InferenceRule<T> {
 
@@ -64,7 +63,7 @@ public class StrictInferenceRule<T extends Invertable> extends InferenceRule<T> 
 
 	@Override
 	public StrictInferenceRule<T> clone() {
-		StrictInferenceRule<T> rule = new StrictInferenceRule<T>();
+		StrictInferenceRule<T> rule = new StrictInferenceRule<>();
 		rule.addPremises(this.getPremise());
 		rule.setConclusion(this.getConclusion());
 		return rule;
@@ -76,7 +75,7 @@ public class StrictInferenceRule<T extends Invertable> extends InferenceRule<T> 
 		StrictInferenceRule<T> n = this.clone();
 		Signature sig = this.getSignature();
 		if (sig instanceof FolSignature) {
-			n = new StrictInferenceRule<T>();
+			n = new StrictInferenceRule<>();
 			RelationalFormula c2 = ((RelationalFormula) this.getConclusion()).substitute(v, t);
 			for (T x : this.getPremise()) {
 				RelationalFormula p2 = ((RelationalFormula) x).substitute(v, t);

--- a/org-tweetyproject-arg-aspic/src/test/java/org/tweetyproject/arg/aspic/AspicTest.java
+++ b/org-tweetyproject-arg-aspic/src/test/java/org/tweetyproject/arg/aspic/AspicTest.java
@@ -18,14 +18,8 @@
  */
  package org.tweetyproject.arg.aspic;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
+import java.util.*;
 
 import org.junit.Test;
 
@@ -57,8 +51,12 @@ import org.tweetyproject.logics.pl.parser.PlParser;
 import org.tweetyproject.logics.pl.syntax.Proposition;
 import org.tweetyproject.logics.pl.syntax.PlFormula;
 
+import static org.junit.Assert.*;
+
 /**
- * @author Nils Geilen Several JUnit test for the package arg.aspic
+ * Several JUnit test for the package arg.aspic
+ *
+ * @author Nils Geilen
  */
 public class AspicTest {
 
@@ -71,7 +69,7 @@ public class AspicTest {
 	public void Example1() throws Exception {
 		AspicParser<PlFormula> parser = new AspicParser<>(new PlParser(), new PlFormulaGenerator());
 		AspicArgumentationTheory<PlFormula> at = parser
-				.parseBeliefBaseFromFile(AspicTest.class.getResource("/ex1.aspic").getFile());
+				.parseBeliefBaseFromFile(Objects.requireNonNull(AspicTest.class.getResource("/ex1.aspic")).getFile());
 
 		AspicArgument<PlFormula> A1 = new AspicArgument<>(
 				(InferenceRule<PlFormula>) parser.parseFormula("->p"));
@@ -114,7 +112,7 @@ public class AspicTest {
 		B3.addDirectSub(B2);
 		for (Attack attack : dt.getAttacks())
 			if (attack.getAttacked().equals(A3))
-				assertTrue(attack.getAttacker().equals(B3));
+				assertEquals(attack.getAttacker(), B3);
 	}
 
 	/**
@@ -128,7 +126,7 @@ public class AspicTest {
 		PlParser plparser = new PlParser();
 		AspicParser<PlFormula> parser = new AspicParser<>(plparser, new PlFormulaGenerator());
 		AspicArgumentationTheory<PlFormula> at = parser
-				.parseBeliefBaseFromFile(AspicTest.class.getResource("/ex2.aspic").getFile());
+				.parseBeliefBaseFromFile(Objects.requireNonNull(AspicTest.class.getResource("/ex2.aspic")).getFile());
 
 		InferenceRule<PlFormula> snores = (InferenceRule<PlFormula>) parser
 				.parseFormula("p1: => Snores"),
@@ -139,25 +137,25 @@ public class AspicTest {
 
 		Collection<AspicArgument<PlFormula>> args = at.getArguments();
 		AspicArgument<PlFormula> A3 = null, B1 = null;
-		PlFormula access = (PlFormula) plparser.parseFormula("!AccessDenied"),
-				no_access = (PlFormula) plparser.parseFormula("AccessDenied");
+		PlFormula access = plparser.parseFormula("!AccessDenied"),
+				no_access = plparser.parseFormula("AccessDenied");
 		for (AspicArgument<PlFormula> arg : args)
 			if (arg.getConclusion().equals(access))
 				B1 = arg;
 			else if (arg.getConclusion().equals(no_access))
 				A3 = arg;
-		assertTrue(A3 != null);
-		assertTrue(B1 != null);
+		assertNotNull(A3);
+		assertNotNull(B1);
 
 		at.setOrder(new LastLinkOrder<>(rule_comp, prem_comp, true));
 		DungTheory dt = at.asDungTheory();
-		assertTrue(((AspicArgument<PlFormula>) dt.getAttacks().iterator().next().getAttacker())
-				.getConclusion().equals(no_access));
+		assertEquals(((AspicArgument<PlFormula>) dt.getAttacks().iterator().next().getAttacker())
+				.getConclusion(), no_access);
 
 		at.setOrder(new WeakestLinkOrder<>(rule_comp, prem_comp, true));
 		dt = at.asDungTheory();
-		assertTrue(((AspicArgument<PlFormula>) dt.getAttacks().iterator().next().getAttacker())
-				.getConclusion().equals(access));
+		assertEquals(((AspicArgument<PlFormula>) dt.getAttacks().iterator().next().getAttacker())
+				.getConclusion(), access);
 	}
 
 	/**
@@ -171,23 +169,23 @@ public class AspicTest {
 		PlParser plparser = new PlParser();
 		AspicParser<PlFormula> parser = new AspicParser<>(plparser, new PlFormulaGenerator());
 		AspicArgumentationTheory<PlFormula> at = parser
-				.parseBeliefBaseFromFile(AspicTest.class.getResource("/ex3.aspic").getFile());
+				.parseBeliefBaseFromFile(Objects.requireNonNull(AspicTest.class.getResource("/ex3.aspic")).getFile());
 
 		Comparator<InferenceRule<PlFormula>> rule_comp = new RuleComparator<>(
 				Arrays.asList("d1", "d3", "d2"));
 
 		Collection<AspicArgument<PlFormula>> args = at.getArguments();
 		AspicArgument<PlFormula> B2 = null;
-		PlFormula not = (PlFormula) plparser.parseFormula("! LikesWhisky");
+		PlFormula not = plparser.parseFormula("! LikesWhisky");
 		for (AspicArgument<PlFormula> arg : args)
 			if (arg.getConclusion().equals(not))
 				B2 = arg;
-		assertTrue(B2 != null);
+		assertNotNull(B2);
 
 		at.setOrder(new WeakestLinkOrder<>(rule_comp, new RuleComparator<>(new ArrayList<>()), true));
 		DungTheory dt = at.asDungTheory();
-		assertTrue(((AspicArgument<PlFormula>) dt.getAttacks().iterator().next().getAttacker())
-				.getConclusion().equals(not));
+		assertEquals(((AspicArgument<PlFormula>) dt.getAttacks().iterator().next().getAttacker())
+				.getConclusion(), not);
 	}
 
 	/**
@@ -201,10 +199,10 @@ public class AspicTest {
 		PlParser plparser = new PlParser();
 		AspicParser<PlFormula> parser = new AspicParser<>(plparser, new PlFormulaGenerator());
 		AspicArgumentationTheory<PlFormula> at = parser
-				.parseBeliefBaseFromFile(AspicTest.class.getResource("/ex4.aspic").getFile());
+				.parseBeliefBaseFromFile(Objects.requireNonNull(AspicTest.class.getResource("/ex4.aspic")).getFile());
 
 		DungTheory dt = at.asDungTheory();
-		assertTrue(dt.getAttacks().size() == 4);
+		assertEquals(4, dt.getAttacks().size());
 		for (Attack a : dt.getAttacks())
 			assertFalse(((AspicArgument<PlFormula>) a.getAttacker()).getTopRule().isDefeasible());
 	}
@@ -223,11 +221,11 @@ public class AspicTest {
 		r1.addPremise(c);
 		t.addRule(r1);
 
-		StrictInferenceRule<PlFormula> s1 = new StrictInferenceRule<PlFormula>();
+		StrictInferenceRule<PlFormula> s1 = new StrictInferenceRule<>();
 		s1.setConclusion(b);
 		t.addRule(s1);
 
-		s1 = new StrictInferenceRule<PlFormula>();
+		s1 = new StrictInferenceRule<>();
 		s1.setConclusion(c);
 		t.addRule(s1);
 
@@ -237,15 +235,19 @@ public class AspicTest {
 	}
 
 	@Test
-	public void ComplementTest() throws Exception {
+	public void ComplementTest() {
 		PlFormula f = new Proposition("a");
-		assertTrue(f.equals(f.complement().complement()));
+		assertEquals(f, f.complement().complement());
 	}
 
 	@Test
 	public void ParserTest1() throws Exception {
 		FolParser folparser = new FolParser();
-		String folbsp = "Animal = {horse, cow, lion} \n" + "type(Tame(Animal)) \n" + "type(Ridable(Animal)) \n";
+		String folbsp = """
+				Animal = {horse, cow, lion}\s
+				type(Tame(Animal))\s
+				type(Ridable(Animal))\s
+				""";
 		folparser.parseBeliefBase(folbsp);
 		AspicParser<FolFormula> aspicparser = new AspicParser<>(folparser, folfg);
 		aspicparser.setSymbolComma(";");
@@ -253,7 +255,7 @@ public class AspicTest {
 		aspicparser.setSymbolStrict("-->");
 		String aspicbsp = "d1: Tame(cow) ==> Ridable(cow)\n" + "s1 : Tame(horse) && Ridable(lion) --> Tame(horse)";
 		AspicArgumentationTheory<FolFormula> aat = aspicparser.parseBeliefBase(aspicbsp);
-		assertTrue(aat.size() == 2);
+		assertEquals(2, aat.size());
 	}
 
 	@Test
@@ -263,9 +265,12 @@ public class AspicTest {
 		aspicparser.setSymbolComma(";");
 		aspicparser.setSymbolDefeasible("==>");
 		aspicparser.setSymbolStrict("-->");
-		String aspicbsp = "d1: a ==> b\n" + "s1 : c; d ==> e \n" + "d ; r --> a";
+		String aspicbsp = """
+				d1: a ==> b
+				s1 : c; d ==> e\s
+				d ; r --> a""";
 		AspicArgumentationTheory<FolFormula> aat = aspicparser.parseBeliefBase(aspicbsp);
-		assertTrue(aat.size() == 3);
+		assertEquals(3, aat.size());
 	}
 
 	@Test
@@ -276,7 +281,7 @@ public class AspicTest {
 		Collection<AspicArgument<PlFormula>> args = at.getArguments();
 		// for(AspicArgument<PropositionalFormula> a:args)
 		// System.out.println(a);
-		assertTrue(args.size() == 8);
+		assertEquals(8, args.size());
 		for (AspicArgument<PlFormula> a : args)
 			if (a.getConclusion().equals(new Proposition("f")) || a.getConclusion().equals(new Proposition("g")))
 				assertTrue(a.hasDefeasibleSub());
@@ -288,7 +293,13 @@ public class AspicTest {
 	@Test
 	public void AttackTest() throws Exception {
 		AspicParser<PlFormula> parser = new AspicParser<>(new PlParser(), pfg);
-		String input = "=> ! a \n" + " => a \n" + "-> ! b \n" + "-> b \n" + "a,b->c\n";
+		String input = """
+				=> ! a\s
+				 => a\s
+				-> ! b\s
+				-> b\s
+				a,b->c
+				""";
 		AspicArgumentationTheory<PlFormula> at = parser.parseBeliefBase(input);
 		Collection<AspicArgument<PlFormula>> args = at.getArguments();
 
@@ -312,7 +323,7 @@ public class AspicTest {
 			if (AspicAttack.isAttack(not_a, arg, null, null))
 				sum++;
 		}
-		assertTrue(sum == 2);
+		assertEquals(2, sum);
 		for (AspicArgument<PlFormula> arg : args) {
 			assertFalse(AspicAttack.isAttack(not_b, arg, null, null));
 		}
@@ -332,12 +343,17 @@ public class AspicTest {
 	@Test
 	public void PropositionalFormulaGeneratorTest() throws Exception {
 		AspicParser<PlFormula> parser = new AspicParser<>(new PlParser(), pfg);
-		String input = "-> a \n" + "d1: a => b \n" + "d2: a => !d1 \n" + "s1: a -> e \n" + "s2: a -> !s1";
+		String input = """
+				-> a\s
+				d1: a => b\s
+				d2: a => !d1\s
+				s1: a -> e\s
+				s2: a -> !s1""";
 		AspicArgumentationTheory<PlFormula> at = parser.parseBeliefBase(input);
 		DungTheory dt = at.asDungTheory();
-		assertTrue(dt.getAttacks().size() == 1);
-		assertTrue(((AspicArgument<PlFormula>) dt.getAttacks().iterator().next().getAttacked())
-				.getConclusion().equals(new Proposition("b")));
+		assertEquals(1, dt.getAttacks().size());
+		assertEquals(((AspicArgument<PlFormula>) dt.getAttacks().iterator().next().getAttacked())
+				.getConclusion(), new Proposition("b"));
 	}
 
 	
@@ -361,34 +377,39 @@ public class AspicTest {
 	@Test
 	public void SimpleOrderTest() throws Exception {
 		AspicParser<PlFormula> parser = new AspicParser<>(new PlParser(), pfg);
-		String input = "=> BornInScotland\n" + " => FitnessLover \n" + "d1: BornInScotland => Scottish \n"
-				+ "d2: Scottish => LikesWhiskey \n" + "d3: FitnessLover => ! LikesWhiskey\n", order = "d1<d3<d2";
+		String input = """
+				=> BornInScotland
+				 => FitnessLover\s
+				d1: BornInScotland => Scottish\s
+				d2: Scottish => LikesWhiskey\s
+				d3: FitnessLover => ! LikesWhiskey
+				""", order = "d1<d3<d2";
 		AspicArgumentationTheory<PlFormula> at = parser.parseBeliefBase(input + order);
 
 		DungTheory dt = at.asDungTheory();
-		assertTrue(dt.getNodes().size() == 5);
-		assertTrue(dt.getAttacks().size() == 1);
-		assertTrue(((AspicArgument<PlFormula>) dt.getAttacks().iterator().next().getAttacker()).getTopRule()
-				.getName().equals("d2"));
+		assertEquals(5, dt.getNodes().size());
+		assertEquals(1, dt.getAttacks().size());
+		assertEquals("d2", ((AspicArgument<PlFormula>) dt.getAttacks().iterator().next().getAttacker()).getTopRule()
+				.getName());
 
 		Comparator<AspicArgument<PlFormula>> new_order = parser.parseSimpleOrder("d1<d2<d3");
 		at.setOrder(new_order);
 		dt = at.asDungTheory();
-		assertTrue(dt.getNodes().size() == 5);
-		assertTrue(dt.getAttacks().size() == 1);
-		assertTrue(((AspicArgument<PlFormula>) dt.getAttacks().iterator().next().getAttacker()).getTopRule()
-				.getName().equals("d3"));
+		assertEquals(5, dt.getNodes().size());
+		assertEquals(1, dt.getAttacks().size());
+		assertEquals("d3", ((AspicArgument<PlFormula>) dt.getAttacks().iterator().next().getAttacker()).getTopRule()
+				.getName());
 
 		at.setOrder(new SimpleAspicOrder<>());
 		dt = at.asDungTheory();
-		assertTrue(dt.getNodes().size() == 5);
-		assertTrue(dt.getAttacks().size() == 2);
+		assertEquals(5, dt.getNodes().size());
+		assertEquals(2, dt.getAttacks().size());
 
 		at = parser.parseBeliefBase(input);
 		at.setRuleFormulaGenerator(pfg);
 		dt = at.asDungTheory();
-		assertTrue(dt.getNodes().size() == 5);
-		assertTrue(dt.getAttacks().size() == 2);
+		assertEquals(5, dt.getNodes().size());
+		assertEquals(2, dt.getAttacks().size());
 	}
 
 	
@@ -397,11 +418,11 @@ public class AspicTest {
 		PlParser plparser = new PlParser();
 		AspicParser<PlFormula> parser = new AspicParser<>(plparser, new PlFormulaGenerator());
 		AspicArgumentationTheory<PlFormula> at = parser
-				.parseBeliefBaseFromFile(AspicTest.class.getResource("/ex1.aspic").getFile());
+				.parseBeliefBaseFromFile(Objects.requireNonNull(AspicTest.class.getResource("/ex1.aspic")).getFile());
 		
-		SimpleAspicReasoner<PlFormula> ar = new SimpleAspicReasoner<PlFormula>(AbstractExtensionReasoner.getSimpleReasonerForSemantics(Semantics.CONFLICTFREE_SEMANTICS));
+		SimpleAspicReasoner<PlFormula> ar = new SimpleAspicReasoner<>(AbstractExtensionReasoner.getSimpleReasonerForSemantics(Semantics.CONFLICTFREE_SEMANTICS));
 
-		PlFormula pf = (PlFormula)plparser.parseFormula("p");
+		PlFormula pf = plparser.parseFormula("p");
 
 		System.out.println(pf);
 		assertTrue(ar.query(at,pf,InferenceMode.CREDULOUS));
@@ -446,20 +467,18 @@ public class AspicTest {
 
 		PlParser plparser = new PlParser();
 		AspicParser<PlFormula> parser = new AspicParser<>(plparser, new PlFormulaGenerator());
-		DirectionalAspicReasoner<PlFormula> directionalReasoner = new DirectionalAspicReasoner<PlFormula>(AbstractExtensionReasoner.getSimpleReasonerForSemantics(Semantics.GR));
-		PlFormula queryFormula = (PlFormula)plparser.parseFormula(query);
+		DirectionalAspicReasoner<PlFormula> directionalReasoner = new DirectionalAspicReasoner<>(AbstractExtensionReasoner.getSimpleReasonerForSemantics(Semantics.GR));
+		PlFormula queryFormula = plparser.parseFormula(query);
 		
 		// Generate full
 		AspicArgumentationTheory<PlFormula> fullAt = parser.parseBeliefBase(full);
 		DungTheory dt = directionalReasoner.asRestrictedDungTheory(fullAt, false, queryFormula);
-		Collection<Argument> fullArgs = new ArrayList<Argument>();
-		fullArgs.addAll(dt);
+		Collection<Argument> fullArgs = new ArrayList<>(dt);
 
 		// Generate partial
 		AspicArgumentationTheory<PlFormula> partialAt = parser.parseBeliefBase(partial);
 		dt = directionalReasoner.asRestrictedDungTheory(partialAt, false, queryFormula);
-		Collection<Argument> partialArgs = new ArrayList<Argument>();
-		partialArgs.addAll(dt);
+		Collection<Argument> partialArgs = new ArrayList<>(dt);
 		
 		return fullArgs.equals(partialArgs);
 

--- a/org-tweetyproject-arg-dung/pom.xml
+++ b/org-tweetyproject-arg-dung/pom.xml
@@ -1,50 +1,45 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <groupId>org.tweetyproject.arg</groupId>
   <artifactId>dung</artifactId>
-  
+
   <name>TweetyProject (Dung Argumentation Library)</name>
 
   <parent>
-  <groupId>org.tweetyproject</groupId>
-  <artifactId>parent-pom</artifactId>
-  	<version>1.22-SNAPSHOT</version>
-  	<relativePath>..</relativePath>
+    <groupId>org.tweetyproject</groupId>
+    <artifactId>parent-pom</artifactId>
+    <version>1.22-SNAPSHOT</version>
+    <relativePath>..</relativePath>
   </parent>
   <dependencies>
-  	<dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.9</version>
       <scope>test</scope>
     </dependency>
-  	<dependency>
-  		<groupId>org.tweetyproject</groupId>
-  		<artifactId>commons</artifactId>
-  		<version>1.22-SNAPSHOT</version>
-  	</dependency>
-  	<dependency>
-  		<groupId>org.tweetyproject</groupId>
-  		<artifactId>graphs</artifactId>
-  		<version>1.22-SNAPSHOT</version>
-  	</dependency>
-  	  	<dependency>
-  		<groupId>org.tweetyproject</groupId>
-  		<artifactId>math</artifactId>
-  		<version>1.22-SNAPSHOT</version>
-  	</dependency>
-
-  	<dependency>
-  		<groupId>org.tweetyproject</groupId>
-  		<artifactId>math</artifactId>
-  		<version>1.22-SNAPSHOT</version>
-  	</dependency>
-  	<dependency>
-  		<groupId>org.tweetyproject.logics</groupId>
-  		<artifactId>pl</artifactId>
-  		<version>1.22-SNAPSHOT</version>
-  	</dependency>
+    <dependency>
+      <groupId>org.tweetyproject</groupId>
+      <artifactId>commons</artifactId>
+      <version>1.22-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.tweetyproject</groupId>
+      <artifactId>graphs</artifactId>
+      <version>1.22-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.tweetyproject</groupId>
+      <artifactId>math</artifactId>
+      <version>1.22-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.tweetyproject.logics</groupId>
+      <artifactId>pl</artifactId>
+      <version>1.22-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 </project>
 

--- a/org-tweetyproject-commons/src/main/java/org/tweetyproject/commons/InferenceMode.java
+++ b/org-tweetyproject-commons/src/main/java/org/tweetyproject/commons/InferenceMode.java
@@ -20,25 +20,18 @@ package org.tweetyproject.commons;
 
 /**
  * Enum constants for the two classical inference models of skeptical inference (assess
- * a formula as true iff it is contained in every model) and credoulous inference
+ * a formula as true iff it is contained in every model) and credulous inference
  * (assess a formula as true iff it is contained in some model).
  * 
  * @author Matthias Thimm
- *
- */
-
-/**
- * enum fr Inference
- *
  */
 public enum InferenceMode {
-	//skeptical, credulous
 	/**
-	 * SKEPTICAL
+	 * Skeptical inference assesses a formula as true iff it is contained in <strong>every</strong> model
 	 */
 	SKEPTICAL,
 	/**
-	 * CREDULOUS
+	 * Credulous inference assesses a formula as true iff it is contained in <strong>some</strong> model
 	 */
 	CREDULOUS
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.tweetyproject</groupId>
@@ -8,13 +9,20 @@
   <version>1.22-SNAPSHOT</version>
   <packaging>pom</packaging>
 
-  <description>TweetyProject is a collection of various Java libraries that implement approaches to different areas of artificial intelligence. In particular, it provides a general interface layer for doing research and working with different knowledge representation formalisms such as classical logics, conditional logics, probabilistic logics, and argumentation. Furthermore, TweetyProject contains libraries for dealing with agents, multi-agent systems, and dialog systems for agents, as well as belief revision, preference reasoning, preference aggregation, and action languages. A series of utility libraries that deal with e.g. mathematical optimization complement the collection.</description>
+  <description>TweetyProject is a collection of various Java libraries that implement approaches to different areas of
+    artificial intelligence. In particular, it provides a general interface layer for doing research and working
+    with different knowledge representation formalisms such as classical logics, conditional logics, probabilistic
+    logics, and argumentation. Furthermore, TweetyProject contains libraries for dealing with agents, multi-agent
+    systems, and dialog systems for agents, as well as belief revision, preference reasoning, preference
+    aggregation, and action languages. A series of utility libraries that deal with e.g. mathematical optimization
+    complement the collection.
+  </description>
   <url>http://tweetyproject.org</url>
 
   <scm>
-     <url>https://github.com/TweetyProjectTeam/TweetyProject</url>
-     <connection>scm:git:https://github.com/TweetyProjectTeam/TweetyProject.git</connection>
-     <developerConnection>scm:git:https://github.com/TweetyProjectTeam/TweetyProject.git</developerConnection>
+    <url>https://github.com/TweetyProjectTeam/TweetyProject</url>
+    <connection>scm:git:https://github.com/TweetyProjectTeam/TweetyProject.git</connection>
+    <developerConnection>scm:git:https://github.com/TweetyProjectTeam/TweetyProject.git</developerConnection>
   </scm>
 
   <developers>
@@ -26,13 +34,13 @@
   </developers>
 
   <!-- For third-party jars that are not in the central repository -->
-<repositories>
-	<repository>
-	    <id>tweety-mvn</id>
-	    <name>TweetyProject MVN Repository</name>
-    	<url>https://tweetyproject.org/mvn</url>
-	</repository>
-</repositories>
+  <repositories>
+    <repository>
+      <id>tweety-mvn</id>
+      <name>TweetyProject MVN Repository</name>
+      <url>https://tweetyproject.org/mvn</url>
+    </repository>
+  </repositories>
 
   <licenses>
     <license>
@@ -44,31 +52,31 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-   <maven.compiler.source>15</maven.compiler.source>
-   <maven.compiler.target>15</maven.compiler.target>
-</properties>
+    <maven.compiler.source>15</maven.compiler.source>
+    <maven.compiler.target>15</maven.compiler.target>
+  </properties>
 
   <distributionManagement>
-	<snapshotRepository>
+    <snapshotRepository>
       <id>ossrh</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
   </distributionManagement>
 
   <build>
-<!--
-  <resources>
-    <resource>
-      <directory>src/main/resources</directory>
-    </resource>
-    <resource>
-      <directory>src/main/java</directory>
-      <includes>
+    <!--
+      <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>src/main/java</directory>
+        <includes>
         <include>**/*.java</include>
-      </includes>
-    </resource>
-  </resources>
-   -->
+        </includes>
+      </resource>
+      </resources>
+       -->
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -81,38 +89,39 @@
       </plugin>
       <!-- Generate jar containing the sources of the project: -->
       <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-source-plugin</artifactId>
-      <version>2.2.1</version>
-      <executions>
-        <execution>
-          <id>attach-sources</id>
-          <goals>
-            <goal>jar-no-fork</goal>
-          </goals>
-        </execution>
-      </executions>
-      <configuration>
-          <outputDirectory>../testBuild</outputDirectory>
-          <finalName>${project.groupId}.${project.artifactId}-${project.version}</finalName>
-        </configuration>
-    </plugin>
-    <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-javadoc-plugin</artifactId>
-      <executions>
-        <execution>
-          <id>attach-javadocs</id>
-          <goals>
-            <goal>jar</goal>
-          </goals>
-        </execution>
-      </executions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
           <outputDirectory>../testBuild</outputDirectory>
           <finalName>${project.groupId}.${project.artifactId}-${project.version}</finalName>
         </configuration>
-    </plugin>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.4.1</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <outputDirectory>../testBuild</outputDirectory>
+          <finalName>${project.groupId}.${project.artifactId}-${project.version}</finalName>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
@@ -122,8 +131,8 @@
           <outputDirectory>../testBuild</outputDirectory>
         </configuration>
       </plugin>
-    <!--
-     <plugin>
+      <!--
+       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>2.3</version>
@@ -136,14 +145,14 @@
         </configuration>
         <executions>
           <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
+          <phase>package</phase>
+          <goals>
+            <goal>shade</goal>
+          </goals>
           </execution>
         </executions>
-      </plugin>
-  -->
+        </plugin>
+      -->
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
@@ -173,52 +182,51 @@
   </build>
 
   <modules>
-  	<module>org-tweetyproject-commons</module>
-  	<module>org-tweetyproject-math</module>
-  	<module>org-tweetyproject-action</module>
-  	<module>org-tweetyproject-beliefdynamics</module>
-  	<module>org-tweetyproject-cli</module>
-  	<module>org-tweetyproject-graphs</module>
-  	<module>org-tweetyproject-preferences</module>
-  	<module>org-tweetyproject-machinelearning</module>
-  	<module>org-tweetyproject-plugin</module>
-  	<module>org-tweetyproject-lp-asp</module>
-  	<module>org-tweetyproject-lp-asp-beliefdynamics</module>
-  	<module>org-tweetyproject-lp-nlp</module>
-  	<module>org-tweetyproject-logics-bpm</module>
-	<module>org-tweetyproject-logics-petri</module>
-  	<module>org-tweetyproject-logics-commons</module>
-  	<module>org-tweetyproject-logics-cl</module>
-  	<module>org-tweetyproject-logics-fol</module>
-  	<module>org-tweetyproject-logics-pl</module>
-  	<module>org-tweetyproject-logics-ml</module>
-  	<module>org-tweetyproject-logics-mln</module>
-  	<module>org-tweetyproject-logics-pcl</module>
+    <module>org-tweetyproject-commons</module>
+    <module>org-tweetyproject-math</module>
+    <module>org-tweetyproject-action</module>
+    <module>org-tweetyproject-beliefdynamics</module>
+    <module>org-tweetyproject-cli</module>
+    <module>org-tweetyproject-graphs</module>
+    <module>org-tweetyproject-preferences</module>
+    <module>org-tweetyproject-machinelearning</module>
+    <module>org-tweetyproject-plugin</module>
+    <module>org-tweetyproject-lp-asp</module>
+    <module>org-tweetyproject-lp-asp-beliefdynamics</module>
+    <module>org-tweetyproject-lp-nlp</module>
+    <module>org-tweetyproject-logics-bpm</module>
+    <module>org-tweetyproject-logics-petri</module>
+    <module>org-tweetyproject-logics-commons</module>
+    <module>org-tweetyproject-logics-cl</module>
+    <module>org-tweetyproject-logics-fol</module>
+    <module>org-tweetyproject-logics-pl</module>
+    <module>org-tweetyproject-logics-ml</module>
+    <module>org-tweetyproject-logics-mln</module>
+    <module>org-tweetyproject-logics-pcl</module>
     <module>org-tweetyproject-logics-qbf</module>
-  	<module>org-tweetyproject-logics-rcl</module>
-  	<module>org-tweetyproject-logics-rdl</module>
-  	<module>org-tweetyproject-logics-rpcl</module>
-  	<module>org-tweetyproject-logics-dl</module>
-  	<module>org-tweetyproject-logics-translators</module>
-  	<module>org-tweetyproject-arg-adf</module>
-  	<module>org-tweetyproject-arg-aspic</module>
+    <module>org-tweetyproject-logics-rcl</module>
+    <module>org-tweetyproject-logics-rdl</module>
+    <module>org-tweetyproject-logics-rpcl</module>
+    <module>org-tweetyproject-logics-dl</module>
+    <module>org-tweetyproject-logics-translators</module>
+    <module>org-tweetyproject-arg-adf</module>
+    <module>org-tweetyproject-arg-aspic</module>
     <module>org-tweetyproject-arg-aba</module>
     <module>org-tweetyproject-arg-bipolar</module>
-  	<module>org-tweetyproject-arg-deductive</module>
-  	<module>org-tweetyproject-arg-lp</module>
-  	<module>org-tweetyproject-arg-delp</module>
-  		<module>org-tweetyproject-arg-setaf</module>
-  	<module>org-tweetyproject-arg-dung</module>
-  	<module>org-tweetyproject-arg-prob</module>
-  	<module>org-tweetyproject-arg-rankings</module>
-  	<module>org-tweetyproject-arg-saf</module>
-
-  	<module>org-tweetyproject-arg-social</module>
-  	<module>org-tweetyproject-agents</module>
-  	<module>org-tweetyproject-agents-dialogues</module>
-  	<module>org-tweetyproject-web</module>
-  	<module>org-tweetyproject</module>
-  	<module>org-tweetyproject-sat</module>
+    <module>org-tweetyproject-arg-deductive</module>
+    <module>org-tweetyproject-arg-lp</module>
+    <module>org-tweetyproject-arg-delp</module>
+    <module>org-tweetyproject-arg-setaf</module>
+    <module>org-tweetyproject-arg-dung</module>
+    <module>org-tweetyproject-arg-prob</module>
+    <module>org-tweetyproject-arg-rankings</module>
+    <module>org-tweetyproject-arg-saf</module>
+    <module>org-tweetyproject-arg-social</module>
+    <module>org-tweetyproject-agents</module>
+    <module>org-tweetyproject-agents-dialogues</module>
+    <module>org-tweetyproject-web</module>
+    <module>org-tweetyproject</module>
+    <module>org-tweetyproject-sat</module>
     <module>org-tweetyproject-comparator</module>
   </modules>
 


### PR DESCRIPTION
Changes in org-tweetyproject-arg-aspic module: 
- Fix javadoc errors where misplaced author annotation adding the rest of javadoc as author info 
- Add missing and incomplete javadoc
- Clean up unnecessary type usages where inference is possible
- Simplify test classes for better readability
- Update format for consistency

Changes in org-tweetyproject-arg-dung/pom.xml
- Remove duplicate org.tweetyproject.math dependency

Changes in root pom:
- Add version to maven-javadoc-plugin
- Format to have consistent spacing

