### PR TITLE
Run tests in CI

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,28 @@
+name: Package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          # Compile source and target are still specified in pom.xml
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven
+        run: mvn --batch-mode package
+
+      # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+      - name: Update dependency graph
+        uses: advanced-security/maven-dependency-submission-action@v4

--- a/org-tweetyproject-arg-setaf/src/test/java/SetAfTheoryTest.java
+++ b/org-tweetyproject-arg-setaf/src/test/java/SetAfTheoryTest.java
@@ -17,10 +17,7 @@
  *  Copyright 2021 The TweetyProject Team <http://tweetyproject.org/contact/>
  */
 
-
-
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -36,6 +33,7 @@ import org.tweetyproject.arg.setaf.reasoners.*;
  * Examples of SetAf Theorys and their semantics
  * 
  * @author Sebastian Franke
+ * @author Oleksandr Dzhychko
  *
  */
 public class SetAfTheoryTest {
@@ -69,12 +67,10 @@ public class SetAfTheoryTest {
 		String grS = gr.getModel(s).toString();
 		String adS = ad.getModels(s).toString();
 		String prS = pr.getModels(s).toString();
-		
-		assertTrue(grS.equals("{b,d}"));
-		assertTrue(adS.equals("[{b}, {d}, {b,d}, {}]"));
-		assertTrue(prS.equals("[{b,d}]"));
 
-
+        assertEquals("{b,c,d}", grS);
+        assertEquals("[{b}, {d}, {b,d}, {b,c,d}, {}]", adS);
+        assertEquals("[{b,c,d}]", prS);
 	}
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
           </execution>
         </executions>
         <configuration>
-          <outputDirectory>../testBuild</outputDirectory>
+          <outputDirectory>./testBuild</outputDirectory>
           <finalName
                     >${project.groupId}.${project.artifactId}-${project.version}</finalName>
         </configuration>
@@ -125,7 +125,7 @@
           </execution>
         </executions>
         <configuration>
-          <outputDirectory>../testBuild</outputDirectory>
+          <outputDirectory>./testBuild</outputDirectory>
           <finalName
                     >${project.groupId}.${project.artifactId}-${project.version}</finalName>
         </configuration>
@@ -137,7 +137,7 @@
         <configuration>
           <finalName
                     >${project.groupId}.${project.artifactId}-${project.version}</finalName>
-          <outputDirectory>../testBuild</outputDirectory>
+          <outputDirectory>./testBuild</outputDirectory>
         </configuration>
       </plugin>
       <!--


### PR DESCRIPTION
This PR configures the test to be run for PRs to  `main` and commits on `main`.
This should prevent broken tests or code on `main`.

It also:
- fixes a broken test
- fixes a missconfiguration in the `pom.xml` that caused errors during builds with Maven.

